### PR TITLE
Allow Preference for Route Connectivity

### DIFF
--- a/scripts/online_status_icon.sh
+++ b/scripts/online_status_icon.sh
@@ -4,6 +4,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 online_option_string="@online_icon"
 offline_option_string="@offline_icon"
+route_to_ping_string="@route_to_ping"
 
 online_icon_osx="✅ "
 online_icon="✔ "
@@ -32,8 +33,12 @@ offline_icon_default() {
 	fi
 }
 
+route_to_ping_default() {
+  echo "www.google.com"
+}
+
 online_status() {
-	ping -c 3 www.google.com >/dev/null 2>&1
+	ping -c 3 $(get_tmux_option "$route_to_ping_string" "$(route_to_ping_default)" >/dev/null 2>&1
 }
 
 print_icon() {


### PR DESCRIPTION
Just out of a minor concern for privacy, allowing users to specify which 
routes they'd like to hit to determine network connectivity. This is also
since google.com can be available in a capacitively-blocked network, thus 
providing a false positive. One route Google Chrome uses to determine network
connectivity is `http://clients3.google.com/generate_204` [docs](http://www.chromium.org/chromium-os/chromiumos-design-docs/network-portal-detection).
