### PR TITLE
Use Reachability (scutil) on macOS

### DIFF
--- a/scripts/online_status_icon.sh
+++ b/scripts/online_status_icon.sh
@@ -48,18 +48,26 @@ offline_icon_default() {
 }
 
 online_status() {
-	if is_osx || is_freebsd; then
+	local ping_timeout="$(get_tmux_option "$ping_timeout_string" "$ping_timeout_default")"
+	local ping_route="$(get_tmux_option "$route_to_ping_string" "$route_to_ping_default")"
+
+	if is_osx; then
+		scutil -r "$ping_route" | grep "^Reachable$" > /dev/null 2>&1
+		return $?
+	fi
+
+	if is_freebsd; then
 		local timeout_flag="-t"
 	else
 		local timeout_flag="-w"
 	fi
+
 	if is_cygwin; then
 		local number_pings_flag="-n"
 	else
 		local number_pings_flag="-c"
 	fi
-	local ping_timeout="$(get_tmux_option "$ping_timeout_string" "$ping_timeout_default")"
-	local ping_route="$(get_tmux_option "$route_to_ping_string" "$route_to_ping_default")"
+
 	ping "$number_pings_flag" 1 "$timeout_flag" "$ping_timeout" "$ping_route" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
This uses [scutil](https://ss64.com/osx/scutil.html) to read the Reachability API. This can give you a fairly accurate representation of your network connectivity without sending an ICMP packet every N seconds.

https://developer.apple.com/documentation/systemconfiguration/scnetworkreachability-g7d