### PR TITLE
Make git treat gif/png images as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Force text files to have unix eols, so Windows/Cygwin does not break them
 *.* eol=lf
+
+*.gif binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.* eol=lf
 
 *.gif binary
+*.png binary


### PR DESCRIPTION
This makes sure that git does not change CRLF to LF in screenshot.gif on Linux.