### PR TITLE
Add plugin_interpolated_options support

### DIFF
--- a/online_status.tmux
+++ b/online_status.tmux
@@ -21,7 +21,10 @@ update_tmux_option() {
 }
 
 main() {
-	update_tmux_option "status-right"
-	update_tmux_option "status-left"
+	local interpolated_options="$(get_tmux_option "@plugin_interpolated_options" "status-right status-left")"
+	for interpolated_option in $interpolated_options
+	do
+		update_tmux_option $interpolated_option
+	done
 }
 main


### PR DESCRIPTION
When using a multi-line status-format, having the interpolation restricted to status_left and status_right is problematic.

This adds an option to configure which options are interpolated by the plugin. Because there are multiple plugins using the same interpolation technique, and they are all subject to the same restrictions, I used "@plugin_interpolated_options" as the option name. That option could be reused by other plugins for the same purpose.

If the option is not found, it defaults to "status-right status-left", the current behavior.


To support multi-line status-format, the status line to interpolate can be added to @plugin_interpolated_options in ~/.tmux.conf:

`set -g @plugin_interpolated_options 'status-format[0] status-left status-right'`


This option also allows a very small improvement in startup performance by only interpolating the necessary options. For example, to only interpolate status-right:

`set -g @plugin_interpolated_options 'status-right'`